### PR TITLE
changed api url

### DIFF
--- a/mainapp/urls.py
+++ b/mainapp/urls.py
@@ -66,6 +66,6 @@ urlpatterns = [
     url(r'c/(?P<pk>\d+)/(?P<ts>\d+)/$', views.VolunteerConsent.as_view(), name='volunteer_consent'),
     url('missing_and_finding_persons/', views.ReportFindPerson.as_view(), name='report_find_person'),
     url('hospitals/', views.HospitalView.as_view(), name='hospitals'),
-    url('announcements/api', views.announcement_api, name='announcements_api'),
+    url('api/announcements', views.announcement_api, name='announcements_api'),
 
 ]


### PR DESCRIPTION


### Issue Reference
This PR addresses the Issue : Fixes #1060

### Summarize
changed api url from announcements/api to api/announcements/api as i believe it clashed with announcements/<string:filter>

